### PR TITLE
Upgrade astartectl and Astarte version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,4 +17,4 @@ jobs:
           astartectl config current-context
           astartectl config contexts show $(astartectl config current-context)
           export DEVICE_ID=$(astartectl utils device-id generate-random)
-          astartectl pairing agent register $DEVICE_ID
+          astartectl pairing agent register -- $DEVICE_ID

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ For more information, reference the GitHub Help Documentation for [Creating a wo
 
 ### Inputs
 
-- `astarte_chart_version`: The Helm chart version for Astarte Operator. Defaults to the last one in the 1.x series.
-- `astarte_version`: The Astarte version to install. This will match both the Operator and the Astarte version. Defaults to `1.0.1`.
+- `astarte_chart_version`: The Helm chart version for Astarte Operator. Defaults to the last one in the 22.11.xx series.
+- `astarte_version`: The Astarte version to install. This will match both the Operator and the Astarte version. Defaults to `1.0.4`.
 - `astarte_realm`: The Astarte Realm that will be created with the cluster. Defaults to `test`.
 - `astarte_namespace`: The Kubernetes namespace where Astarte will be installed. Defaults to `astarte`.
 - `kind_version`: The kind version to use (default: `v0.11.1`). Advised to leave as default.

--- a/action.yml
+++ b/action.yml
@@ -11,13 +11,13 @@ inputs:
     required: false
     default: "astarte"
   astarte_chart_version:
-    description: "The Astarte Helm Chart version to use. Defaults to ^1.0.0"
+    description: "The Astarte Helm Chart version to use. Defaults to ^22.11.00"
     required: false
-    default: "^1.0.0"
+    default: "^22.11.00"
   astarte_version:
-    description: "The Astarte version to install. This will match both the Operator and Astarte version. Defaults to 1.0.1"
+    description: "The Astarte version to install. This will match both the Operator and Astarte version. Defaults to 1.0.4"
     required: false
-    default: "1.0.1"
+    default: "1.0.4"
   astarte_realm:
     description: "The Astarte realm to create. Defaults to `test`. If empty, no realm will be created and the realm_key output will be empty."
     required: false
@@ -70,7 +70,7 @@ runs:
         kubectl get pods -n kube-system
     - name: Install Operator and its dependencies
       shell: bash
-      run: ${{ github.action_path }}/install-operator.sh "${{ inputs.astarte_chart_version }}" "${{ inputs.astarte_version }}"
+      run: ${{ github.action_path }}/install-operator.sh "${{ inputs.astarte_chart_version }}"
     - name: Setup Astarte Kubernetes namespace
       shell: bash
       run: kubectl create namespace "${{ inputs.astarte_namespace }}"

--- a/install-operator.sh
+++ b/install-operator.sh
@@ -10,7 +10,7 @@ helm repo update
 
 # Install cert-manager
 kubectl create namespace cert-manager
-helm install cert-manager jetstack/cert-manager --namespace cert-manager --version v1.1.0 --set installCRDs=true || exit 1
+helm install cert-manager jetstack/cert-manager --namespace cert-manager --version v1.10.0 --set installCRDs=true || exit 1
 
 # Wait for everything to settle
 kubectl wait --namespace ingress-nginx \
@@ -19,7 +19,7 @@ kubectl wait --namespace ingress-nginx \
   --timeout=90s || exit 1
 
 # Install Astarte operator
-helm install astarte-operator astarte/astarte-operator --version "$1" --set image.tag="$2" || exit 1
+helm install astarte-operator astarte/astarte-operator --version "$1" || exit 1
 
 # Wait 10s for it to settle
 sleep 10

--- a/setup-astarte.sh
+++ b/setup-astarte.sh
@@ -2,8 +2,8 @@
 
 tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
 cd $tmp_dir
-wget -q https://github.com/astarte-platform/astartectl/releases/download/v1.0.0-beta.7/astartectl_1.0.0-beta.7_linux_x86_64.tar.gz
-tar xf astartectl_1.0.0-beta.7_linux_x86_64.tar.gz
+wget -q https://github.com/astarte-platform/astartectl/releases/download/v22.11.00/astartectl_22.11.00_linux_x86_64.tar.gz
+tar xf astartectl_22.11.00_linux_x86_64.tar.gz
 chmod +x astartectl
 cd -
 
@@ -14,7 +14,7 @@ echo "$tmp_dir" >> $GITHUB_PATH
 # Deploy a burst instance
 astartectl cluster instances deploy --version "$1" --api-host "api.autotest.astarte-platform.org" --broker-host "broker.autotest.astarte-platform.org" \
     --broker-port 8883 --broker-tls-secret test-certificate --vernemq-volume-size "4G" --rabbitmq-volume-size "4G" \
-    --cassandra-volume-size "4G" --name "astarte" --namespace "$2" --profile "burst" -y || exit 1
+    --cassandra-volume-size "4G" --name "astarte" --namespace "$2" --burst -y || exit 1
 
 echo "Waiting for Astarte Cluster to be ready..."
 


### PR DESCRIPTION
Bump both astartectl and Astarte to the latest version.
According to the new Astarte Kubernetes Operator versioning scheme, the Astarte Kubernetes Operator version is no more bound to Astarte's. Contextually, bump default values, too.