### PR TITLE
Bump tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For more information, reference the GitHub Help Documentation for [Creating a wo
 ### Inputs
 
 - `astarte_chart_version`: The Helm chart version for Astarte Operator. Defaults to the last one in the 22.11.xx series.
-- `astarte_version`: The Astarte version to install. This will match both the Operator and the Astarte version. Defaults to `1.0.4`.
+- `astarte_version`: The Astarte version to install. Defaults to `1.1.0`.
 - `astarte_realm`: The Astarte Realm that will be created with the cluster. Defaults to `test`.
 - `astarte_namespace`: The Kubernetes namespace where Astarte will be installed. Defaults to `astarte`.
 - `kind_version`: The kind version to use (default: `v0.11.1`). Advised to leave as default.

--- a/action.yml
+++ b/action.yml
@@ -11,13 +11,13 @@ inputs:
     required: false
     default: "astarte"
   astarte_chart_version:
-    description: "The Astarte Helm Chart version to use. Defaults to ^22.11.00"
+    description: "The Astarte Operator Helm Chart version to use. Defaults to ^22.11.00"
     required: false
-    default: "^22.11.00"
+    default: "^22.11.01"
   astarte_version:
     description: "The Astarte version to install. This will match both the Operator and Astarte version. Defaults to 1.0.4"
     required: false
-    default: "1.0.4"
+    default: "1.1.0"
   astarte_realm:
     description: "The Astarte realm to create. Defaults to `test`. If empty, no realm will be created and the realm_key output will be empty."
     required: false

--- a/setup-astarte.sh
+++ b/setup-astarte.sh
@@ -2,8 +2,8 @@
 
 tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
 cd $tmp_dir
-wget -q https://github.com/astarte-platform/astartectl/releases/download/v22.11.00/astartectl_22.11.00_linux_x86_64.tar.gz
-tar xf astartectl_22.11.00_linux_x86_64.tar.gz
+wget -q https://github.com/astarte-platform/astartectl/releases/download/v22.11.03/astartectl_22.11.03_linux_x86_64.tar.gz
+tar xf astartectl_22.11.03_linux_x86_64.tar.gz
 chmod +x astartectl
 cd -
 


### PR DESCRIPTION
- Default to astarte 1.1.0
- Use astarte operator 22.11.01
- Bump KinD to 0.20.0 (and k8s to 1.26)
 
Contextually, reflect changes in the readme.