### PR TITLE
refactor(outputs): use the `$GITHUB_OUTPUT` variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,6 @@ inputs:
     required: false
     default: "kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e"
 
-
 outputs:
   housekeeping_key:
     description: "The Housekeeping private key of the new cluster"
@@ -88,13 +87,27 @@ runs:
       run: cd "${{ github.action_path }}" && astartectl utils gen-keypair "${{ inputs.astarte_realm }}" && cd -
     - name: load-realm-key
       shell: bash
-      run: echo "::set-output name=realm-key::$(cat ${{ github.action_path }}/${{ inputs.astarte_realm }}_private.pem)"
+      env:
+        REALM_KEY: "${{ github.action_path }}/${{ inputs.astarte_realm }}_private.pem"
+      run: |
+        {
+          echo 'realm-key<<EOF'
+          cat  "$REALM_KEY"
+          echo 'EOF'
+        } >> "$GITHUB_OUTPUT"
     - name: Get housekeeping key
       shell: bash
       run: kubectl get secrets -n "${{ inputs.astarte_namespace }}" astarte-housekeeping-private-key -o jsonpath={.data.private-key} | base64 -d > "${{ github.action_path }}"/housekeeping_key.pem
     - id: load-housekeeping-key
       shell: bash
-      run: echo "::set-output name=housekeeping-key::$(cat ${{ github.action_path }}/housekeeping_key.pem)"
+      env:
+        HOUSEKEEPING_KEY: "${{ github.action_path }}/housekeeping_key.pem"
+      run: |
+        {
+          echo "housekeeping-key<<EOF"
+          cat "$HOUSEKEEPING_KEY"
+          echo 'EOF'
+        } >> "$GITHUB_OUTPUT"
     - name: Create Astarte Realm
       shell: bash
       run: astartectl housekeeping realms create -y "${{ inputs.astarte_realm }}" -u http://api.autotest.astarte-platform.org --realm-public-key "${{ github.action_path }}/${{ inputs.astarte_realm }}"_public.pem -k "${{ github.action_path }}/housekeeping_key.pem"


### PR DESCRIPTION
Use the `$GITHUB_OUTPUT` variable instead of ::set-output to resolve a deprecation warning downstream.

See:
- [deprecation notice](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
- [docs for milti-line variables](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#multiline-strings)