### PR TITLE
chore: prepare for v2.0.0-alpha.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
-## [1.3.0] - Unreleased
+## [2.0.0-alpha.0] - 2026-04-10
 
-BREAKING: Given the amount breaking changes introduces between Astarte 1.2.x and Astarte 1.3.x (and related Operator versions), the Astarte Cluster GitHub Action v1.3+ is only compatible with Astarte 1.3.x and Astarte Operator 26.5.x. It is advised to use Astarte Cluster GitHub Action v1.2 to use previous versions of Astarte.
+BREAKING: Given the amount breaking changes introduces between Astarte 1.2.x and Astarte 1.3.x (and related Operator versions), the Astarte Cluster GitHub Action v2+ is only compatible with Astarte 1.3.x and Astarte Operator 26.5.x. It is advised to use Astarte Cluster GitHub Action v1.2 to use previous versions of Astarte.
 
 ### Added
 - Support for Astarte 1.3.x and Astarte Kubernetes Operator 26.5.x.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ For more information, reference the GitHub Help Documentation for [Creating a wo
 
 ### Inputs
 
-- `astarte_chart_version`: The Helm chart version for Astarte Operator. Default: `26.5.0-dev`.
+- `astarte_chart_version`: The Helm chart version for Astarte Operator. Default: `26.5.0-alpha.0`.
 - `astartectl_version`: The astartectl CLI version to install. Default: `24.5.3`.
 - `astarte_version`: The Astarte version to install. Default: `1.3.0-rc.2`.
 - `astarte_realm`: The Astarte Realm that will be created with the cluster. Default: `test`. If empty, no realm is created.
@@ -106,4 +106,4 @@ This uses [@astarte-platform/astarte-cluster-action](https://github.com/astarte-
 |:------------------------------:|:-------------------:|:-----------------------------------:|
 | v1.2.0                         | v1.0 - v1.2.0       | v24.5                               |
 | v1.2.0                         | v1.2.1 - v1.2.x     | v24.5.2                             |
-| v1.3.0 (unreleased)            | v1.3+               | v26.5                               |
+| v2.0.0-alpha.0                 | v1.3+               | v26.5                               |

--- a/action.yml
+++ b/action.yml
@@ -27,9 +27,9 @@ inputs:
     required: false
     default: "v1.20.2"
   astarte_chart_version:
-    description: "The Astarte Operator Helm Chart version to use. Defaults to 26.5.0-dev"
+    description: "The Astarte Operator Helm Chart version to use. Defaults to 26.5.0-alpha.0"
     required: false
-    default: "26.5.0-dev"
+    default: "26.5.0-alpha.0"
   astartectl_version:
     description: "The astartectl CLI version to use. Defaults to 24.5.3"
     required: false


### PR DESCRIPTION
Prepare for v2.0.0-alpha.0 release
- Update versions and documentation accordingly.
- Set Astarte Operator default version to 26.5.0-alpha.0.