### PR TITLE
chore: prepare for v2.0.0 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
         id: create-astarte-cluster
         uses: ./
         with:
-          astarte_version: "1.3-snapshot"
+          astarte_version: "1.3.0"
           astarte_realm: "customrealm"
           astarte_namespace: "astarte-test-namespace"
       - name: Test cluster functionality (register a device)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [2.0.0] - 2026-05-07
+- Bump to latest stable versions for Astarte, Astarte Operator, astartectl.
+
 ## [2.0.0-alpha.0] - 2026-04-10
 
 BREAKING: Given the amount breaking changes introduces between Astarte 1.2.x and Astarte 1.3.x (and related Operator versions), the Astarte Cluster GitHub Action v2+ is only compatible with Astarte 1.3.x and Astarte Operator 26.5.x. It is advised to use Astarte Cluster GitHub Action v1.2 to use previous versions of Astarte.

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ For more information, reference the GitHub Help Documentation for [Creating a wo
 
 ### Inputs
 
-- `astarte_chart_version`: The Helm chart version for Astarte Operator. Default: `26.5.0-alpha.0`.
-- `astartectl_version`: The astartectl CLI version to install. Default: `24.5.3`.
-- `astarte_version`: The Astarte version to install. Default: `1.3.0-rc.2`.
+- `astarte_chart_version`: The Helm chart version for Astarte Operator. Default: `26.5.1`.
+- `astartectl_version`: The astartectl CLI version to install. Default: `26.5.0`.
+- `astarte_version`: The Astarte version to install. Default: `1.3.0`.
 - `astarte_realm`: The Astarte Realm that will be created with the cluster. Default: `test`. If empty, no realm is created.
 - `astarte_namespace`: The Kubernetes namespace where Astarte will be installed. Defaults to `astarte`.
 - `kind_version`: The kind version to use (default: `v0.31.0`). Advised to leave as default.
@@ -106,4 +106,4 @@ This uses [@astarte-platform/astarte-cluster-action](https://github.com/astarte-
 |:------------------------------:|:-------------------:|:-----------------------------------:|
 | v1.2.0                         | v1.0 - v1.2.0       | v24.5                               |
 | v1.2.0                         | v1.2.1 - v1.2.x     | v24.5.2                             |
-| v2.0.0-alpha.0                 | v1.3+               | v26.5                               |
+| v2.0.0                         | v1.3+               | v26.5                               |

--- a/action.yml
+++ b/action.yml
@@ -29,15 +29,15 @@ inputs:
   astarte_chart_version:
     description: "The Astarte Operator Helm Chart version to use. Defaults to 26.5.0-alpha.0"
     required: false
-    default: "26.5.0-alpha.0"
+    default: "26.5.1"
   astartectl_version:
     description: "The astartectl CLI version to use. Defaults to 24.5.3"
     required: false
-    default: "24.5.3"
+    default: "26.5.0"
   astarte_version:
     description: "The Astarte version to install. Defaults to 1.3.0-rc.2"
     required: false
-    default: "1.3.0-rc.2"
+    default: "1.3.0"
   astarte_realm:
     description: "The Astarte realm to create. Defaults to `test`. If empty, no realm will be created and the realm_key output will be empty."
     required: false


### PR DESCRIPTION
Prepare for v2.0.0 release by:
- Update all the version references.
- Bump to latest stable versions for Astarte, Astarte Operator, astartectl.