### PR TITLE
refactor(cert): add wildcard host for FDO endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Add the `kustomize_astarte_patch` input to patch the Astarte resource before it's applied
+- Add the `*.api.autotest.astarte-platform.org` wildcard host to the test certificate
 
 ## [2.0.0] - 2026-05-07
 - Bump to latest stable versions for Astarte, Astarte Operator, astartectl.

--- a/certs/cert.json
+++ b/certs/cert.json
@@ -1,21 +1,22 @@
 {
-    "CN": "api.autotest.astarte-platform.org",
-    "key": {
-        "algo": "rsa",
-        "size": 2048
-    },
-    "names": [
-        {
-            "C": "IT",
-            "L": "Arezzo",
-            "O": "Astarte",
-            "OU": "Astarte Autotest Hosts",
-            "ST": "Italy"
-        }
-    ],
-    "hosts": [
-        "api.autotest.astarte-platform.org",
-        "broker.autotest.astarte-platform.org",
-        "localhost"
-    ]
+  "CN": "api.autotest.astarte-platform.org",
+  "key": {
+    "algo": "rsa",
+    "size": 2048
+  },
+  "names": [
+    {
+      "C": "IT",
+      "L": "Arezzo",
+      "O": "Astarte",
+      "OU": "Astarte Autotest Hosts",
+      "ST": "Italy"
+    }
+  ],
+  "hosts": [
+    "api.autotest.astarte-platform.org",
+    "broker.autotest.astarte-platform.org",
+    "*.api.autotest.astarte-platform.org",
+    "localhost"
+  ]
 }


### PR DESCRIPTION
This is needed to call the FDO pairing api url with the realm prefixed
to it. For example
`https://test.api.autotest.astarte-example.org/fdo/msg/255`.